### PR TITLE
Install shared media folder in -core-dev

### DIFF
--- a/ubuntu/debian/libignition-rendering-core-dev.install
+++ b/ubuntu/debian/libignition-rendering-core-dev.install
@@ -6,3 +6,4 @@ usr/lib/*/libignition-rendering[0-99].so
 usr/lib/*/pkgconfig/ignition-rendering[0-99].pc
 usr/lib/*/cmake/ignition-rendering[0-99]/ignition-rendering*
 usr/share/ignition/ignition-rendering[0-99]/ignition-rendering*.tag.xml
+usr/share/ignition/ignition-rendering[0-99]/media/*


### PR DESCRIPTION
A com.png texture was added recently in https://github.com/ignitionrobotics/ign-rendering/pull/345 but not included in any package install files, so this adds the new media folder to -core-dev.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering6-debbuilder&build=175)](https://build.osrfoundation.org/job/ign-rendering6-debbuilder/175/) https://build.osrfoundation.org/job/ign-rendering6-debbuilder/175/

~~~
dh_missing: usr/share/ignition/ignition-rendering6/media/materials/textures/com.png exists in debian/tmp but is not installed to anywhere
~~~