### PR TITLE
Use libogre-2.2

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -16,7 +16,7 @@ Build-Depends: cmake,
                libignition-math6-dev (>= 6.6.0),
                libignition-plugin-dev,
                libogre-1.9-dev,
-               libogre-2.1-dev
+               libogre-2.2-dev
 Vcs-Browser: https://github.com/ignition-release/ign-rendering6-release
 Vcs-Git: https://github.com/ignition-release/ign-rendering6-release
 Homepage: http://ignitionrobotics.org/
@@ -91,7 +91,7 @@ Depends: libignition-cmake2-dev,
          libignition-common4-events-dev,
          libignition-common4-graphics-dev,
          libignition-math6-dev (>= 6.6.0),
-         libogre-2.1-dev,
+         libogre-2.2-dev,
          libignition-rendering6-core-dev,
          libignition-rendering6-ogre2 (= ${binary:Version}),
          ${misc:Depends}


### PR DESCRIPTION
Nightly builds are broken since https://github.com/ignitionrobotics/ign-rendering/pull/272 was just merged:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering6-debbuilder&build=316)](https://build.osrfoundation.org/job/ign-rendering6-debbuilder/316/) https://build.osrfoundation.org/job/ign-rendering6-debbuilder/316/

This should fix them.