### PR TITLE
Fix ARM compilation of terra libs declared as static

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -17,6 +17,7 @@ endif
 	dh $@ --parallel
 
 override_dh_auto_configure:
+	echo "DEBUG: $(EXTRA_CMAKE_FLAGS) $(DEB_HOST_ARCH_CPU)"
 	dh_auto_configure -- \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo $(EXTRA_CMAKE_FLAGS)
 

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -2,6 +2,12 @@
 # -*- makefile -*-
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_HOST_ARCH_CPU ?= $(shell dpkg-architecture -qDEB_HOST_ARCH_CPU)
+
+EXTRA_CMAKE_FLAGS =
+ifeq ($(DEB_HOST_ARCH_CPU),arm)
+    EXTRA_CMAKE_FLAGS = -DIGN_ADD_fPIC_TO_LIBRARIES=True
+endif
 
 .PHONY: override_dh_auto_configure \
         override_dh_install \
@@ -12,7 +18,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+	    -DCMAKE_BUILD_TYPE=RelWithDebInfo $(EXTRA_CMAKE_FLAGS)
 
 override_dh_install:
 	dh_install --

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -5,7 +5,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_HOST_ARCH_CPU ?= $(shell dpkg-architecture -qDEB_HOST_ARCH_CPU)
 
 EXTRA_CMAKE_FLAGS =
-ifeq ($(DEB_HOST_ARCH_CPU),arm)
+ifneq (,$(filter arm,$(DEB_HOST_ARCH_CPU)))
     EXTRA_CMAKE_FLAGS = -DIGN_ADD_fPIC_TO_LIBRARIES=True
 endif
 

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -5,7 +5,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_HOST_ARCH_CPU ?= $(shell dpkg-architecture -qDEB_HOST_ARCH_CPU)
 
 EXTRA_CMAKE_FLAGS =
-ifneq (,$(filter arm,$(DEB_HOST_ARCH_CPU)))
+ifneq (,$(filter $(DEB_HOST_ARCH_CPU), arm64 armhf))
     EXTRA_CMAKE_FLAGS = -DIGN_ADD_fPIC_TO_LIBRARIES=True
 endif
 
@@ -17,7 +17,6 @@ endif
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	echo "DEBUG: $(EXTRA_CMAKE_FLAGS) $(DEB_HOST_ARCH_CPU)"
 	dh_auto_configure -- \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo $(EXTRA_CMAKE_FLAGS)
 


### PR DESCRIPTION
Use `[IGN_ADD_fPIC_TO_LIBRARIES](https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering6/ogre2/src/terrain/Terra/CMakeLists.txt#L11-L13)` in arm to compile terra library using shared library instead of static. This fixes ARM builds: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering6-debbuilder&build=401)](https://build.osrfoundation.org/job/ign-rendering6-debbuilder/401/)

Failing here [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering6-debbuilder&build=390)](https://build.osrfoundation.org/job/ign-rendering6-debbuilder/390/)

