### PR TITLE
Use -DSKIP_optix=true to fix cmake warning

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -18,6 +18,7 @@ endif
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+	    -DSKIP_optix=true \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo $(EXTRA_CMAKE_FLAGS)
 
 override_dh_install:


### PR DESCRIPTION
motivated by:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering6-debbuilder&build=515)](https://build.osrfoundation.org/job/ign-rendering6-debbuilder/515/) https://build.osrfoundation.org/job/ign-rendering6-debbuilder/515/