### PR TITLE
Missing x11-dev and freeglut3-dev as deps of libignition-rendering-dev package

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -41,7 +41,6 @@ Description: Ignition rendering classes and functions for robot apps - Shared li
 # Only for the examples:
 #
 #        libfreeimage-dev,
-#        freeglut3-dev,
 #        libglew-dev,
 
 Package: libignition-rendering6-core-dev
@@ -53,6 +52,8 @@ Depends: libignition-cmake2-dev (>= 2.3.0),
          libignition-math6-dev (>= 6.6.0),
          libignition-math6-eigen3-dev (>= 6.6.0),
          libignition-plugin-dev,
+         libx11-dev,
+         freeglut3-dev,
          libignition-rendering6 (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
Found missing dependencies while developing the rendering code
